### PR TITLE
Removed Bjørn from instructor list

### DIFF
--- a/right_column.md
+++ b/right_column.md
@@ -59,7 +59,6 @@ Python.
 
 - Radovan Bast
 - Anne Fouilloux
-- Bjørn Lindi
 - Pavlin Mitev
 - Sabry Razick
 - Annika Rockenberger


### PR DESCRIPTION
@bast , I am not sure if it is intentional that October workshop website keeps Bjørn's name in the instructor list. If it is the case, please reject this PR.